### PR TITLE
Fix: axios client type error

### DIFF
--- a/generators/infra/templates/httpClient/infra/HttpClientAxios.ts
+++ b/generators/infra/templates/httpClient/infra/HttpClientAxios.ts
@@ -7,9 +7,11 @@ const { NEXT_PUBLIC_API_URL, NEXT_PUBLIC_COOKIE_NAME } = process.env
 
 const client = axios.create({
   baseURL: NEXT_PUBLIC_API_URL,
-  paramsSerializer: createQueryString,
+  paramsSerializer: {
+    serialize: createQueryString,
+  },
   timeout: 7200000,
-})
+});
 
 client.interceptors.request.use((config: AxiosRequestConfig) => {
   const token: string | undefined = cookies.get(NEXT_PUBLIC_COOKIE_NAME as string);

--- a/generators/infra/templates/httpClient/infra/HttpClientAxios.ts
+++ b/generators/infra/templates/httpClient/infra/HttpClientAxios.ts
@@ -24,6 +24,18 @@ client.interceptors.request.use(
   }
 );
 
+function sanitizeParams<Params>(params: Params): Record<string, string> | undefined {
+  return !!params && typeof params == "object" 
+    ? Object.fromEntries(
+        Object.entries(params).filter(([_, v]) => {
+          if (typeof v === "string") return v.length > 0;
+
+          return true;
+        })
+      )
+    : undefined;
+}
+
 export class HttpClientAxios implements IHttpClient {
   async request<Response, Payload = undefined, Params = undefined>({
     url,
@@ -34,16 +46,7 @@ export class HttpClientAxios implements IHttpClient {
   }: IHttpClientRequestParams<Payload, Params>): Promise<
     IHttpResponse<Response>
   > {
-    const sanitizedParams = 
-      !!params && typeof params == "object" 
-        ? Object.fromEntries(
-            Object.entries(params).filter(([_, v]) => {
-              if (typeof v === "string") return v.length > 0;
-
-              return true;
-            })
-          )
-        : undefined;
+    const sanitizedParams = sanitizeParams<Params>(params);
 
     const response = await client.request({
       url,

--- a/generators/infra/templates/httpClient/infra/HttpClientAxios.ts
+++ b/generators/infra/templates/httpClient/infra/HttpClientAxios.ts
@@ -1,9 +1,9 @@
 import cookies from "js-cookie";
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { InternalAxiosRequestConfig } from "axios";
 import { IHttpClient, HttpMethod, IHttpResponse } from "@/services/http";
 import { createQueryString } from "@/utils/queryString";
 
-const { NEXT_PUBLIC_API_URL, NEXT_PUBLIC_COOKIE_NAME } = process.env
+const { NEXT_PUBLIC_API_URL, NEXT_PUBLIC_COOKIE_NAME } = process.env;
 
 const client = axios.create({
   baseURL: NEXT_PUBLIC_API_URL,
@@ -13,12 +13,16 @@ const client = axios.create({
   timeout: 7200000,
 });
 
-client.interceptors.request.use((config: AxiosRequestConfig) => {
-  const token: string | undefined = cookies.get(NEXT_PUBLIC_COOKIE_NAME as string);
-  if (token != null) config.headers.Authorization = `Bearer ${token}`;
+client.interceptors.request.use(
+  (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
+    const token: string | undefined = cookies.get(
+      NEXT_PUBLIC_COOKIE_NAME as string
+    );
+    if (token != null) config.headers.Authorization = `Bearer ${token}`;
 
-  return config;
-})
+    return config;
+  }
+);
 
 export class HttpClientAxios implements IHttpClient {
   async request<T, R>(

--- a/generators/infra/templates/httpClient/services/http/IHttpClient.ts
+++ b/generators/infra/templates/httpClient/services/http/IHttpClient.ts
@@ -1,4 +1,4 @@
-import { HttpMethod } from "./HttpMethod";
+import { IHttpClientRequestParams } from "./IHttpClientRequestParams";
 import { IHttpResponse } from "./IHttpResponse";
 
 export interface IHttpClient {
@@ -8,11 +8,5 @@ export interface IHttpClient {
     params,
     payload,
     baseURL,
-  }: {
-    url: string;
-    method: HttpMethod;
-    params?: Params;
-    payload?: Payload;
-    baseURL?: string;
-  }) => Promise<IHttpResponse<Response>>;
+  }: IHttpClientRequestParams<Payload, Params>) => Promise<IHttpResponse<Response>>;
 }

--- a/generators/infra/templates/httpClient/services/http/IHttpClientRequestParams.ts
+++ b/generators/infra/templates/httpClient/services/http/IHttpClientRequestParams.ts
@@ -1,0 +1,9 @@
+import { HttpMethod } from "./HttpMethod";
+
+export interface IHttpClientRequestParams<Payload = undefined, Params = undefined> {
+  url: string;
+  method: HttpMethod;
+  params?: Params;
+  payload?: Payload;
+  baseURL?: string;
+}

--- a/generators/infra/templates/httpClient/services/http/index.ts
+++ b/generators/infra/templates/httpClient/services/http/index.ts
@@ -2,3 +2,4 @@ export * from "./HttpMethod";
 export * from "./HttpStatusCode";
 export * from "./IHttpClient";
 export * from "./IHttpResponse";
+export * from "./IHttpClientRequestParams";

--- a/source/constants/infra.js
+++ b/source/constants/infra.js
@@ -13,7 +13,7 @@ module.exports = {
       value: InfraEnum.HTTP_CLIENT,
       name: 'HTTP Client',
       dependencies: ['axios', 'js-cookie'],
-      devDependencies: ['@types/axios'],
+      devDependencies: [],
       utils: [utilsEnum.QUERY_STRING],
     },
     {


### PR DESCRIPTION
This pull request fixes HttpClientAxios type errors and update the implementation of IHttpClient. In addition to that, removes the deprecated dev dependency from [@types/axios](https://www.npmjs.com/package/@types/axios).

Resolves Issue #6 

(This new pull request has the new branch source as the [main](https://github.com/novahaus/clean-stack-generator/tree/main))